### PR TITLE
add accommodation endpoint

### DIFF
--- a/api/models/capacityMixin.py
+++ b/api/models/capacityMixin.py
@@ -36,6 +36,12 @@ class CapacityMixin(models.Model):
             return self.number_of_reservations() < self.capacity
         return True
 
+    def available_capacity(self):
+        """
+        Returns number of avaliable places
+        """
+        return self.capacity - self.number_of_reservations()
+
     class Meta:
         """Makes the model abstract."""
 

--- a/api/rest/accomodations.py
+++ b/api/rest/accomodations.py
@@ -1,0 +1,37 @@
+from rest_framework import permissions, serializers, viewsets
+
+from ..models import Accomodation, AccomodationPhoto
+
+
+class AccomodationPhotoSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = AccomodationPhoto
+        fields = (
+            'id',
+            'image',
+            'desc',
+        )
+
+
+class AccomodationSerializer(serializers.HyperlinkedModelSerializer):
+    photos = AccomodationPhotoSerializer(many=True, read_only=True)
+    available = serializers.IntegerField(source='available_capacity')
+
+    class Meta:
+        model = Accomodation
+        fields = (
+            'id',
+            'name',
+            'desc',
+            'capacity',
+            'price',
+            'photos',
+            'available',
+        )
+
+
+class AccomodationViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Accomodation.objects.all()
+    serializer_class = AccomodationSerializer
+    permission_classes = [permissions.AllowAny]
+    allowed_methods = ('GET',)

--- a/api/tests/models/test_accomodation.py
+++ b/api/tests/models/test_accomodation.py
@@ -28,6 +28,7 @@ class AccomodationTest(TestCase):
         )
         accomodation = reservation.accomodation
         self.assertEqual(accomodation.number_of_reservations(), 1)
+        self.assertEqual(accomodation.available_capacity(), 0)
         self.assertEqual(accomodation.has_free_capacity(), False)
 
     @freeze_time("2017-2-1")
@@ -40,6 +41,7 @@ class AccomodationTest(TestCase):
         )
         accomodation = reservation.accomodation
         self.assertEqual(accomodation.number_of_reservations(), 0)
+        self.assertEqual(accomodation.available_capacity(), 1)
         self.assertEqual(accomodation.has_free_capacity(), True)
 
     @freeze_time("2017-2-1")
@@ -52,4 +54,5 @@ class AccomodationTest(TestCase):
         )
         accomodation = reservation.accomodation
         self.assertEqual(accomodation.number_of_reservations(), 1)
+        self.assertEqual(accomodation.available_capacity(), 0)
         self.assertEqual(accomodation.has_free_capacity(), False)

--- a/improtreskApi/rest_router.py
+++ b/improtreskApi/rest_router.py
@@ -1,6 +1,6 @@
 from rest_framework import routers
 
-from api.rest import lectors, workshops, years
+from api.rest import accomodations, lectors, workshops, years
 from api_textual.rest import news, texts
 
 router = routers.DefaultRouter()
@@ -9,3 +9,4 @@ router.register(r'news', news.NewsViewSet)
 router.register(r'texts', texts.TextViewSet)
 router.register(r'years', years.YearViewSet)
 router.register(r'workshops', workshops.WorkshopViewSet)
+router.register(r'accomodations', accomodations.AccomodationViewSet)


### PR DESCRIPTION
Change in parameter name `text->desc`, I could rename that, but now it corresponds with model name.