### PR TITLE
unify endpoint for creating and retrieving orders

### DIFF
--- a/improtreskApi/rest_router.py
+++ b/improtreskApi/rest_router.py
@@ -14,7 +14,6 @@ class NestedDefaultRouter(NestedRouterMixin, routers.DefaultRouter):
 
 router = NestedDefaultRouter()
 router.register(r'accomodationCapacity', accomodations.AccomodationCapacityViewSet)
-router.register(r'createOrders', orders.CreateOrderViewSet, base_name="createOrders")
 router.register(r'lectorRoles', lector_roles.LectorRoleViewSet)
 router.register(r'lectors', lectors.LectorViewSet)
 router.register(r'news', news.NewsViewSet)


### PR DESCRIPTION
You can now both retrieve and create orders on `/api/orders`.