### PR TITLE
Feature/order cancelation

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -193,6 +193,7 @@ class ReservationAdmin(BaseAdminModel):
 class OrderAdmin(BaseAdminModel):
     """Admin model for Orders."""
 
+    list_display = ('participant', 'created_at', 'price', 'canceled', 'paid', 'over_paid')
     readonly_fields = ['symvar', 'paid', 'price']
 
 


### PR DESCRIPTION
PR for issue #125

The endpoint is at `/api/orders/` `DELETE` method. If you consider it too confusing, I can change it to different URL.